### PR TITLE
Add a name to the yum repository

### DIFF
--- a/manifests/repository/redhat.pp
+++ b/manifests/repository/redhat.pp
@@ -13,6 +13,7 @@ class opensearch_dashboards::repository::redhat {
 
   yumrepo { 'opensearch-dashboards':
     ensure        => $opensearch_dashboards::repository_ensure,
+    descr         => 'OpenSearch Dashboards',
     baseurl       => $baseurl,
     repo_gpgcheck => '1',
     gpgcheck      => '1',


### PR DESCRIPTION
Fix warning:
Repository 'opensearch-dashboards' is missing name in configuration, using id
